### PR TITLE
#12 Refactor, Feat: Post Entity, Repository class 수정

### DIFF
--- a/src/main/java/com/example/journeyednt/converter/StringListConverter.java
+++ b/src/main/java/com/example/journeyednt/converter/StringListConverter.java
@@ -1,0 +1,34 @@
+package com.example.journeyednt.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import lombok.SneakyThrows;
+
+import java.util.Collections;
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @SneakyThrows
+    @Override
+    public String convertToDatabaseColumn(List<String> strings) {
+        if (strings == null) {
+            return "";
+        }
+        return mapper.writeValueAsString(strings);
+    }
+
+    @SneakyThrows
+    @Override
+    public List<String> convertToEntityAttribute(String s) {
+        if (s == null || s.isEmpty()) {
+            return Collections.emptyList();
+        }
+        TypeReference<List<String>> typeRef = new TypeReference<>() {};
+        return mapper.readValue(s, typeRef);
+    }
+}

--- a/src/main/java/com/example/journeyednt/entity/Post.java
+++ b/src/main/java/com/example/journeyednt/entity/Post.java
@@ -30,7 +30,7 @@ public class Post {
     @Column(name = "create_at", nullable = false)
     private LocalDateTime createAt;
 
-    @Column(name = "update_at", nullable = false)
+    @Column(name = "update_at")
     private LocalDateTime updateAt;
 
     @Column(name = "is_visible", nullable = false)
@@ -55,7 +55,7 @@ public class Post {
     private Integer rating;
 
     @Builder
-    public Post(Integer id, String title, String content, LocalDateTime createAt, LocalDateTime updateAt, Boolean isVisible, Boolean isNotice, List<String> tags, Integer rating) {
+    public Post(Integer id, String title, String content, LocalDateTime createAt, LocalDateTime updateAt, Boolean isVisible, Boolean isNotice, List<String> tags, Integer rating, User user, Country country) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -65,6 +65,8 @@ public class Post {
         this.isNotice = isNotice;
         this.tags = tags;
         this.rating = rating;
+        this.user = user;
+        this.country = country;
     }
 
     public void updatePost(String title, String content, LocalDateTime updateAt, Boolean isVisible, List<String> tags, Integer rating) {
@@ -83,6 +85,9 @@ public class Post {
                 .isNotice(isNotice)
                 .tags(tags)
                 .rating(rating)
+                .createAt(LocalDateTime.now())
+                .updateAt(LocalDateTime.now())
+                .isVisible(true)
                 .build();
     }
 }

--- a/src/main/java/com/example/journeyednt/entity/Post.java
+++ b/src/main/java/com/example/journeyednt/entity/Post.java
@@ -78,7 +78,7 @@ public class Post {
         this.rating = rating;
     }
 
-    public static Post of(String title, String content, Boolean isNotice, List<String> tags, Integer rating) {
+    public static Post of(String title, String content, Boolean isNotice, List<String> tags, Integer rating, User user) {
         return Post.builder()
                 .title(title)
                 .content(content)
@@ -88,6 +88,7 @@ public class Post {
                 .createAt(LocalDateTime.now())
                 .updateAt(LocalDateTime.now())
                 .isVisible(true)
+                .user(user)
                 .build();
     }
 }

--- a/src/main/java/com/example/journeyednt/entity/Post.java
+++ b/src/main/java/com/example/journeyednt/entity/Post.java
@@ -1,9 +1,11 @@
 package com.example.journeyednt.entity;
 
+import com.example.journeyednt.converter.StringListConverter;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import jakarta.persistence.Id;
 
@@ -37,32 +39,50 @@ public class Post {
     @Column(name = "is_notice", nullable = false)
     private Boolean isNotice;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Column(name = "tag")
+    @Convert(converter = StringListConverter.class)
+    private List<String> tags;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cdd_id")
+    private Country country;
+
+    @Column(name = "rating", nullable = false)
+    private Integer rating;
+
     @Builder
-    public Post(String title, String content, LocalDateTime createAt, LocalDateTime updateAt, Boolean isVisible, Boolean isNotice) {
+    public Post(Integer id, String title, String content, LocalDateTime createAt, LocalDateTime updateAt, Boolean isVisible, Boolean isNotice, List<String> tags, Integer rating) {
+        this.id = id;
         this.title = title;
         this.content = content;
         this.createAt = createAt;
         this.updateAt = updateAt;
         this.isVisible = isVisible;
         this.isNotice = isNotice;
+        this.tags = tags;
+        this.rating = rating;
     }
 
-    public void updatePost(String title, String content, LocalDateTime updateAt, Boolean isVisible) {
+    public void updatePost(String title, String content, LocalDateTime updateAt, Boolean isVisible, List<String> tags, Integer rating) {
         this.title = title;
         this.content = content;
         this.updateAt = updateAt;
         this.isVisible = isVisible;
+        this.tags = tags;
+        this.rating = rating;
     }
 
-    public static Post of(String title, String content, Boolean isNotice) {
+    public static Post of(String title, String content, Boolean isNotice, List<String> tags, Integer rating) {
         return Post.builder()
                 .title(title)
                 .content(content)
                 .isNotice(isNotice)
+                .tags(tags)
+                .rating(rating)
                 .build();
     }
 }

--- a/src/main/java/com/example/journeyednt/repository/PostRepository.java
+++ b/src/main/java/com/example/journeyednt/repository/PostRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,37 +24,79 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
 
     List<Post> findByTitleAndContent(String title, String content); // 제목, 내용으로 게시글을 찾기
 
-    @Query(value = "SELECT p FROM Post p WHERE p.title = :title AND p.isVisible = true")
-    List<Post> findByTitleAndIsVisible(@Param("title") String title);
-    // 제목으로 공개 게시물만 찾기
-
     @Modifying
-    @Transactional
     @Query(value = "UPDATE Post p SET p.isVisible = :isVisible")
     int updateAllPostsVisibility(Boolean isVisible);
     // 모든 게시글의 공개 상태를 변경하는 벌크 업데이트
 
     @Modifying
-    @Transactional
     @Query(value = "UPDATE Post p SET p.isVisible = :isVisible WHERE p.user.id = :userId")
     int updateUserPostsVisibility(Integer userId, Boolean isVisible);
     // 특정 사용자의 모든 게시글의 공개 상태를 변경하는 벌크 업데이트
 
-    @Query(value = "SELECT p.id, p.tags FROM Post p WHERE :tag MEMBER OF (p.tags)", nativeQuery = true)
-    List<Post> findByTag(@Param("tag") String tag);
-    // 특정 태그를 포함하는 게시글 찾기
+    //검색
 
-    @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true")
-    List<Post> findByCityAndCountry(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId);
-    // 시/도, 시/군/구로 공개 게시물 조회
+    @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true ORDER BY p.createAt DESC")
+    List<Post> findByCityAndCountryOrderByCreateAt(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId);
+    // 시/도, 시/군/구로 공개 게시물 최신순으로 조회
 
-    @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true AND :tag MEMBER OF p.tags")
-    List<Post> findByCityCountryAndTag(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId, @Param("tags") List<String> tags);
-    // 시/도, 시/군/구, 그리고 태그를 포함하는 공개게시물 찾기
+    @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true ORDER BY p.rating DESC")
+    List<Post> findByCityAndCountryOrderByRating(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId);
+    // 시/도, 시/군/구로 공개 게시물 평점순으로 조회
 
-    @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true AND p.title LIKE %:title%")
-    List<Post> findByCityCountryAndTitle(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId, @Param("title") String title);
-    // 시/도, 시/군/구, 그리고 제목을 포함하는 공개게시물 찾기
+    @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true AND :tag MEMBER OF (p.tags) ORDER BY p.createAt DESC", nativeQuery = true)
+    List<Post> findByCityCountryAndTagOrderByCreateAt(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId, @Param("tag") String tag);
+    // 시/도, 시/군/구, 그리고 태그를 포함하는 공개게시물 최신순으로 조회 -> String
+
+    /* @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true AND p.tags IN :tags ORDER BY p.createAt DESC")
+     List<Post> findByCityCountryAndTagOrderByCreateAt(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId, @Param("tags") List<String> tags);
+     시/도, 시/군/구, 그리고 태그를 포함하는 공개게시물 최신순으로 조회*/
+
+    @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true AND :tag MEMBER OF (p.tags) ORDER BY p.rating DESC", nativeQuery = true)
+    List<Post> findByCityCountryAndTagOrderByRating(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId, @Param("tag") String tag);
+    // 시/도, 시/군/구, 그리고 태그를 포함하는 공개게시물 평점순으로 조회 -> String
+
+     /*@Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true AND p.tags IN :tags ORDER BY p.rating DESC")
+     List<Post> findByCityCountryAndTagOrderByRating(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId, @Param("tags") List<String> tags);
+     시/도, 시/군/구, 그리고 태그를 포함하는 공개게시물 평점순으로 조회*/
+
+    @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true AND p.title LIKE %:title% ORDER BY p.createAt DESC")
+    List<Post> findByCityCountryAndTitleOrderByCreateAt(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId, @Param("title") String title);
+    // 시/도, 시/군/구, 그리고 제목을 포함하는 공개게시물 최신순으로 조회
+
+    @Query(value = "SELECT p FROM Post p JOIN p.country c JOIN c.city ci WHERE ci.id = :cityId AND c.id = :countryId AND p.isVisible = true AND p.title LIKE %:title% ORDER BY p.rating DESC")
+    List<Post> findByCityCountryAndTitleOrderByRating(@Param("cityId") Integer cityId, @Param("countryId") Integer countryId, @Param("title") String title);
+    // 시/도, 시/군/구, 그리고 제목을 포함하는 공개게시물 평점순으로 조회
+
+    @Query(value = "SELECT p FROM Post p WHERE p.isVisible = true ORDER BY p.createAt DESC")
+    List<Post> findAllPostsByOrderByCreatedAtDesc();
+    // 모든 공개 게시물을 최신순으로 조회
+
+    @Query(value = "SELECT p FROM Post p WHERE p.isVisible = true ORDER BY p.rating DESC")
+    List<Post> findAllPostsByOrderByRatings();
+    // 모든 공개 게시물을 평점순으로 조회
+
+    List<Post> findByTitleAndIsVisibleTrueOrderByCreateAtDesc(String title);
+    // 제목으로 공개 게시물 찾고 최신순으로 조회
+
+    List<Post> findByTitleAndIsVisibleTrueOrderByRatingDesc(String title);
+    // 제목으로 공개 게시물 찾고 평점순으로 조회
+
+    @Query(value = "SELECT p FROM Post p WHERE :tag MEMBER OF (p.tags) AND p.isVisible = true ORDER BY p.createAt DESC", nativeQuery = true)
+    List<Post> findByTagOrderByCreateAtDesc(@Param("tag") String tag);
+    // 특정 태그로 공개 게시물 찾고 최신순으로 조회 -> String
+
+     /*@Query(value = "SELECT p FROM Post p WHERE p.tags IN :tags ORDER BY p.createAt DESC", nativeQuery = true)
+     List<Post> findByTagOrderByCreateAtDesc(@Param("tag") List<String> tags);
+     특정 태그로 공개 게시물 찾고 최신순으로 조회*/
+
+    @Query(value = "SELECT p FROM Post p WHERE :tag MEMBER OF (p.tags) AND p.isVisible = true ORDER BY p.rating DESC", nativeQuery = true)
+    List<Post> findByTagOrderByRatingDesc(@Param("tag") String tag);
+    // 특정 태그로 공개 게시물 찾고 평점순으로 조회 -> String
+
+     /*@Query(value = "SELECT p FROM Post p WHERE p.tags IN :tags ORDER BY p.rating DESC", nativeQuery = true)
+     List<Post> findByTagOrderByRatingDesc(@Param("tag") List<String> tags);
+     특정 태그로 공개 게시물 찾고 평점순으로 조회*/
 }
 
 


### PR DESCRIPTION
Post 엔티티 클래스

- @manytoone(cascade = CascadeType.ALL) 삭제 -> fetch = FetchType.LAZY) 수정
- 태그, 시군구ID, 평점 Column 추가
- Post 생성자 방식 id, 태그, 평점 추가
- updatePost 메서드 태그, 평점추가
- of 메서드 태그, 평점 추가

PostRepository 클래스

- 제목으로 게시글 찾기 코드 수정 -> 쿼리문 사용하여 제목으로 공개 게시물만 찾기 코드 작성
- 벌크 업데이트 쿼리문 -> value = 추가 작성
- 쿼리문 4개 추가 작성

Converter 디렉토리 생성
- entity 구현으로 인한 StringListConverter 클래스 파일 생성 및 코드 작성

-------------------------------------------------------------------------------------------------------- 

0731 Post Entity, Repository 클래스 코드 추가 및 수정

Post 엔티티 클래스
- ERD updateAt  제약조건 null 변경 -> nullable = false 삭제
- Post 생성자 방식 User, Country 코드 추가
- of 메서드 createAt, updateAt, isVisible 코드 추가

PostRepository 
- 벌크 업데이트 부분 -> @Transactional 어노테이션 삭제
- 검색기능 관련 쿼리문 수정 및 추가 작성